### PR TITLE
chore: standardize .github workflows — CodeQL v6

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,13 +29,13 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@v6
         with:
           languages: actions
           queries: "+security-extended"
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@v6
         with:
           category: "/language:actions"
 
@@ -49,13 +49,13 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@v6
         with:
           languages: c-cpp
           build-mode: none
           queries: "+security-extended"
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@v6
         with:
           category: "/language:c-cpp"


### PR DESCRIPTION
Upgrade CodeQL init/analyze to v6 and standardize workflows: checkout@v6, permissions, concurrency. Minimal change.